### PR TITLE
Include zombies/ folder to .pk3

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,3 @@
 cd src/
-7za a -tzip ../build/zombies_v5_upd.pk3 character info weapons zombies.cfg zombies_debug.cfg
+7za a -tzip ../build/zombies_v5_upd.pk3 character info weapons zombies zombies.cfg zombies_debug.cfg
 7za a -tzip ../build/zombies_v5_upd_scripts.pk3 maps


### PR DESCRIPTION
Server complains about missing zombies/module.gsc when starting.

Noticed the zombies/* folder is not included when building pk3 so I updated the build script.